### PR TITLE
Added support for AUR4

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -227,7 +227,7 @@ def Symlink(source_file, dest_file):
 
 def AurInstall(name=None, pkbuild_url=None):
   if name:
-    pkbuild_url = 'https://aur.archlinux.org/packages/%s/%s/PKGBUILD' % (name.lower()[:2], name.lower())
+    pkbuild_url = 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=%s' % name.lower()
   workspace_dir = CreateTempDirectory()
   DownloadFile(pkbuild_url, os.path.join(workspace_dir, 'PKGBUILD'))
   Run(['makepkg', '--asroot'], cwd=workspace_dir)


### PR DESCRIPTION
Arch now uses Git for managing PKGBUILD files.

This uses the cgit web interface to download the plain text PKGBUILD file.
It's sort of a hack, and it might be better to actually checkout the PKGBUILD git repo but this requires only a single line change.

This fixes one small part, but the other changes from https://github.com/jeremyje/compute-archlinux-image-builder (or maybe https://github.com/GoogleCloudPlatform/compute-archlinux-image-builder/pull/7) are needed for this to actually work.

Original pull request https://github.com/jeremyje/compute-archlinux-image-builder/pull/1

I've signed the contribution agreement.

Thanks!