### PR TITLE
Revert "fix MTU settings. MTU is 1460 on gce."

### DIFF
--- a/build-arch-gce
+++ b/build-arch-gce
@@ -139,11 +139,6 @@ arch-chroot -- "$mount_dir" /bin/bash -s -- "$loop_dev" <<-'EOS'
 		google-accounts-daemon google-clock-skew-daemon google-instance-setup \
 		google-network-daemon google-shutdown-scripts google-startup-scripts
 
-	echo "-- setting MTU"
-	cat <<-'EOF' > /etc/udev/rules.d/10-network.rules
-		ACTION=="add", SUBSYSTEM=="net", KERNEL=="en*", ATTR{mtu}="1460"
-	EOF
-
 	echo "-- Configuring initcpio."
 	gawk -i assert -i inplace '
 		/^MODULES=/ { $0 = "MODULES=(virtio_pci virtio_scsi sd_mod ext4)"; ++f1 }


### PR DESCRIPTION
This reverts commit bb393b13c6c3d98ef5d80cf90501b32862a678b2.
MTU is set by DHCP, it shouldn't be set by the udev rule.