### PR TITLE
Don't touch machine-id on the building host

### DIFF
--- a/build-arch-gce
+++ b/build-arch-gce
@@ -167,7 +167,6 @@ EOS
 
 echo "- Cleaning up and finalizing the image."
 > "$mount_dir/etc/machine-id"
-> "$mount_dir/var/lib/dbus/machine-id"
 rm -- "$mount_dir/var/log/pacman.log"
 umount -- "$mount_dir"
 unset mount_dir


### PR DESCRIPTION
Since dbus 1.11.14 [1], `/var/lib/dbus/machine-id` is a symlink to
`/etc/machine-id`, so writing to `"$mount_dir/var/lib/dbus/machine-id"`
actually overwrites `/etc/machine-id` on the building host.

[1] https://gitlab.freedesktop.org/dbus/dbus/commit/ae7568facee0b0d93d7bd1433a0d8840e98f6fb6